### PR TITLE
请求TOKEN前带上当前环境变量的域

### DIFF
--- a/component/interfaceOauth2/interfaceOauth2.js
+++ b/component/interfaceOauth2/interfaceOauth2.js
@@ -67,14 +67,14 @@ class ProjectInterfaceOauth extends Component {
   }
 
   handleClick = (key, data) => {
-    this.setCurOauth(data._id);
+    this.setCurOauth(data._id, data.domain);
     this.setState({
       currentEnvMsg: data,
       currentKey: key
     });
   };
 
-  setCurOauth(envId) {
+  setCurOauth(envId, envDomain) {
     let currOauth = {};
     if (!this.state.projectAllOauth) {
       this.setState({
@@ -89,6 +89,7 @@ class ProjectInterfaceOauth extends Component {
         this.state.projectAllOauth[i].env_id == envId
       ) {
         currOauth = this.state.projectAllOauth[i];
+        currOauth.domain = envDomain;
         break;
       }
     }

--- a/component/oauth2Content/oauth2Content.js
+++ b/component/oauth2Content/oauth2Content.js
@@ -219,7 +219,7 @@ class OAuth2Content extends Component {
     }
     try {
       let res = await axios.post('/api/plugin/oauthInterface/url/valid', {
-        url: get_token_url,
+        url: this.props.envMsg.domain + get_token_url,
         method: request_type,
         headers_data: headers_data,
         dataType,

--- a/model/oauthModel.js
+++ b/model/oauthModel.js
@@ -22,6 +22,8 @@ class oauthModel extends baseModel {
       env_id: String,
       //环境变量的名称
       env_name: String,
+      // 环境变量的域
+      domain: String
       //保存到哪个header上
       token_header: String,
       //上次成功同步接口时间,

--- a/utils/syncTokenUtil.js
+++ b/utils/syncTokenUtil.js
@@ -126,7 +126,7 @@ class syncTokenUtils {
     }
 
     let projectId = projectData._id;
-    let getTokenUrl = oauthData.get_token_url;
+    let getTokenUrl = oauthData.domain + oauthData.get_token_url;
     let method = oauthData.request_type;
     let headers_data = oauthData.headers_data;
     let result;


### PR DESCRIPTION
在实际使用过程中发现，如果yapi与接口没有部署在同一个域或服务器下时，无论是校验token请求地址，还是定时刷新Token时，都没有带上当前环境变量的域，导致请求失败。

修改：

1. 修改了模型，增加了domain字段，存储当前环境变量的域；
2. 修改了前端配置保存方法，将当前环境变量的域也存入数据库；
3. 修改了校验方法，在请求地址前加上了当前环境变量的域
4. 修改了定时刷新获取Token的方法，在请求地址前加上了当前环境变量的域